### PR TITLE
Removed redundant finals for try-with-resource.

### DIFF
--- a/src/main/java/org/orekit/files/sp3/SP3Parser.java
+++ b/src/main/java/org/orekit/files/sp3/SP3Parser.java
@@ -143,9 +143,9 @@ public class SP3Parser implements OrbitFileParser {
 
         final SP3File file = pi.file;
 
-        try (final Scanner s1      = new Scanner(line);
-             final Scanner s2      = s1.useDelimiter("\\s+");
-             final Scanner scanner = s2.useLocale(Locale.US)) {
+        try (Scanner s1      = new Scanner(line);
+             Scanner s2      = s1.useDelimiter("\\s+");
+             Scanner scanner = s2.useLocale(Locale.US)) {
 
             // CHECKSTYLE: stop FallThrough check
 

--- a/src/main/java/org/orekit/utils/IERSConventions.java
+++ b/src/main/java/org/orekit/utils/IERSConventions.java
@@ -1920,7 +1920,7 @@ public enum IERSConventions {
                 plus[i]      = new double[i + 1];
             }
 
-            try (final InputStream stream = IERSConventions.class.getResourceAsStream(nameLove)) {
+            try (InputStream stream = IERSConventions.class.getResourceAsStream(nameLove)) {
 
                 if (stream == null) {
                     // this should never happen with files embedded within Orekit
@@ -1928,7 +1928,7 @@ public enum IERSConventions {
                 }
 
                 // setup the reader
-                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
 
                     String line = reader.readLine();
                     int lineNumber = 1;


### PR DESCRIPTION
This PR is being created because of violations found in CheckStyle's regression of Orekit during implementation of an improvement.
PR: https://github.com/checkstyle/checkstyle/pull/3357
Issue Reasoning: https://github.com/checkstyle/checkstyle/issues/3323#issue-162691860

We are adding `final` for try-with-resource as a redundant modifier because it is implicitly defined as `final` in the JLS. The change produced new violations in Orekit as seen below:
````
[ERROR] src/main/java/org/orekit/utils/IERSConventions.java:[1923,18] (modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/orekit/utils/IERSConventions.java:[1931,22] (modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/orekit/files/sp3/SP3Parser.java:[146,14] (modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/orekit/files/sp3/SP3Parser.java:[147,14] (modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/orekit/files/sp3/SP3Parser.java:[148,14] (modifier) RedundantModifier: Redundant 'final' modifier.
````

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any questions.
Thanks.