### PR TITLE
Removed redundant finals for methods with no declaration

### DIFF
--- a/src/main/java/org/orekit/attitudes/GroundPointing.java
+++ b/src/main/java/org/orekit/attitudes/GroundPointing.java
@@ -93,8 +93,8 @@ public abstract class GroundPointing implements AttitudeProvider {
      * @throws OrekitException if some specific error occurs,
      * such as no target reached
      */
-    protected abstract TimeStampedPVCoordinates getTargetPV(final PVCoordinatesProvider pvProv,
-                                                            final AbsoluteDate date, final Frame frame)
+    protected abstract TimeStampedPVCoordinates getTargetPV(PVCoordinatesProvider pvProv,
+                                                            AbsoluteDate date, Frame frame)
         throws OrekitException;
 
     /** {@inheritDoc} */

--- a/src/main/java/org/orekit/bodies/JPLEphemeridesLoader.java
+++ b/src/main/java/org/orekit/bodies/JPLEphemeridesLoader.java
@@ -180,7 +180,7 @@ public class JPLEphemeridesLoader implements CelestialBodyLoader {
          * @return position-velocity at the specified date
          * @exception OrekitException if the date is not available to the loader
          */
-        PVCoordinates getRawPV(final AbsoluteDate date) throws OrekitException;
+        PVCoordinates getRawPV(AbsoluteDate date) throws OrekitException;
     }
 
     /** Regular expression for supported files names. */

--- a/src/main/java/org/orekit/data/DataProvider.java
+++ b/src/main/java/org/orekit/data/DataProvider.java
@@ -72,7 +72,7 @@ public interface DataProvider {
      * @exception OrekitException if the data loader cannot be fed
      * (read error ...)
      */
-    boolean feed(final Pattern supported, final DataLoader visitor)
+    boolean feed(Pattern supported, DataLoader visitor)
         throws OrekitException;
 
 }

--- a/src/main/java/org/orekit/data/SeriesTerm.java
+++ b/src/main/java/org/orekit/data/SeriesTerm.java
@@ -136,7 +136,7 @@ abstract class SeriesTerm<T extends RealFieldElement<T>> {
      * @param elements luni-solar and planetary elements for the current date
      * @return current value of the argument
      */
-    protected abstract double argument(final BodiesElements elements);
+    protected abstract double argument(BodiesElements elements);
 
     /** Evaluate the value of the series term.
      * @param elements bodies elements for nutation
@@ -170,7 +170,7 @@ abstract class SeriesTerm<T extends RealFieldElement<T>> {
      * @param elements luni-solar and planetary elements for the current date
      * @return current value of the argument
      */
-    protected abstract T argument(final FieldBodiesElements<T> elements);
+    protected abstract T argument(FieldBodiesElements<T> elements);
 
     /** Factory method for building the appropriate object.
      * <p>The method checks the null coefficients and build an instance

--- a/src/main/java/org/orekit/errors/LocalizedException.java
+++ b/src/main/java/org/orekit/errors/LocalizedException.java
@@ -31,7 +31,7 @@ public interface LocalizedException {
      * @param locale Locale in which the message should be translated
      * @return localized message
      */
-    String getMessage(final Locale locale);
+    String getMessage(Locale locale);
 
     /** Get the localizable specifier of the error message.
      * @return localizable specifier of the error message

--- a/src/main/java/org/orekit/estimation/measurements/AbstractMeasurement.java
+++ b/src/main/java/org/orekit/estimation/measurements/AbstractMeasurement.java
@@ -164,8 +164,8 @@ public abstract class AbstractMeasurement<T extends ObservedMeasurement<T>>
      * @exception OrekitException if value cannot be computed
      * @see #estimate(int, int, SpacecraftState)
      */
-    protected abstract EstimatedMeasurement<T> theoreticalEvaluation(final int iteration, final int evaluation,
-                                                                     final SpacecraftState state)
+    protected abstract EstimatedMeasurement<T> theoreticalEvaluation(int iteration, int evaluation,
+                                                                     SpacecraftState state)
         throws OrekitException;
 
     /** {@inheritDoc} */

--- a/src/main/java/org/orekit/estimation/measurements/EstimationModifier.java
+++ b/src/main/java/org/orekit/estimation/measurements/EstimationModifier.java
@@ -52,7 +52,7 @@ public interface EstimationModifier<T extends ObservedMeasurement<T>> {
      * @param estimated estimated measurement to modify
      * @exception OrekitException if modifier cannot be applied
      */
-    void modify(final EstimatedMeasurement<T> estimated)
+    void modify(EstimatedMeasurement<T> estimated)
         throws OrekitException;
 
 }

--- a/src/main/java/org/orekit/files/ccsds/ODMParser.java
+++ b/src/main/java/org/orekit/files/ccsds/ODMParser.java
@@ -102,7 +102,7 @@ public abstract class ODMParser {
      * @return a new instance, with mission reference date replaced
      * @see #getMissionReferenceDate()
      */
-    public abstract ODMParser withMissionReferenceDate(final AbsoluteDate newMissionReferenceDate);
+    public abstract ODMParser withMissionReferenceDate(AbsoluteDate newMissionReferenceDate);
 
     /** Get initial date.
      * @return mission reference date to use while parsing
@@ -117,7 +117,7 @@ public abstract class ODMParser {
      * @return a new instance, with gravitational coefficient date replaced
      * @see #getMu()
      */
-    public abstract ODMParser withMu(final double newMu);
+    public abstract ODMParser withMu(double newMu);
 
     /** Get gravitational coefficient.
      * @return gravitational coefficient to use while parsing
@@ -132,7 +132,7 @@ public abstract class ODMParser {
      * @return a new instance, with IERS conventions replaced
      * @see #getConventions()
      */
-    public abstract ODMParser withConventions(final IERSConventions newConventions);
+    public abstract ODMParser withConventions(IERSConventions newConventions);
 
     /** Get IERS conventions.
      * @return IERS conventions to use while parsing
@@ -147,7 +147,7 @@ public abstract class ODMParser {
      * @return a new instance, with EOP interpolation method replaced
      * @see #isSimpleEOP()
      */
-    public abstract ODMParser withSimpleEOP(final boolean newSimpleEOP);
+    public abstract ODMParser withSimpleEOP(boolean newSimpleEOP);
 
     /** Get EOP interpolation method.
      * @return true if tidal effects are ignored when interpolating EOP
@@ -170,9 +170,9 @@ public abstract class ODMParser {
      * @param newLaunchPiece piece of launch (from "A" to "ZZZ")
      * @return a new instance, with TLE settings replaced
      */
-    public abstract ODMParser withInternationalDesignator(final int newLaunchYear,
-                                                          final int newLaunchNumber,
-                                                          final String newLaunchPiece);
+    public abstract ODMParser withInternationalDesignator(int newLaunchYear,
+                                                          int newLaunchNumber,
+                                                          String newLaunchPiece);
 
     /** Get the launch year.
      * @return launch year
@@ -238,7 +238,7 @@ public abstract class ODMParser {
      * @return parsed orbit
      * @exception OrekitException if orbit message cannot be parsed
      */
-    public abstract ODMFile parse(final InputStream stream, final String fileName)
+    public abstract ODMFile parse(InputStream stream, String fileName)
         throws OrekitException;
 
     /** Parse a comment line.

--- a/src/main/java/org/orekit/files/general/OrbitFile.java
+++ b/src/main/java/org/orekit/files/general/OrbitFile.java
@@ -99,7 +99,7 @@ public interface OrbitFile {
      * @return a {@link SatelliteInformation} object describing the satellite if
      *         present, <code>null</code> otherwise
      */
-    SatelliteInformation getSatellite(final String satId);
+    SatelliteInformation getSatellite(String satId);
 
     /** Tests whether a satellite with the given id is contained in this orbit
      * file.
@@ -107,12 +107,12 @@ public interface OrbitFile {
      * @return <code>true</code> if the satellite is contained in the file,
      *         <code>false</code> otherwise
      */
-    boolean containsSatellite(final String satId);
+    boolean containsSatellite(String satId);
 
     /** Get the time coordinates for the given satellite.
      * @param satId the satellite id
      * @return a {@link List} of {@link SatelliteTimeCoordinate} entries for
      *         this satellite
      */
-    List<SatelliteTimeCoordinate> getSatelliteCoordinates(final String satId);
+    List<SatelliteTimeCoordinate> getSatelliteCoordinates(String satId);
 }

--- a/src/main/java/org/orekit/files/general/OrbitFileParser.java
+++ b/src/main/java/org/orekit/files/general/OrbitFileParser.java
@@ -32,7 +32,7 @@ public interface OrbitFileParser {
      * @exception OrekitException if the orbit file could not be parsed
      * successfully from the given stream
      */
-    OrbitFile parse(final InputStream stream) throws OrekitException;
+    OrbitFile parse(InputStream stream) throws OrekitException;
 
     /** Reads the orbit file and returns a parsed {@link OrbitFile}.
      * @param fileName the file to read and parse
@@ -40,5 +40,5 @@ public interface OrbitFileParser {
      * @exception OrekitException if the orbit file could not be parsed
      * successfully from the given file
      */
-    OrbitFile parse(final String fileName) throws OrekitException;
+    OrbitFile parse(String fileName) throws OrekitException;
 }

--- a/src/main/java/org/orekit/frames/LOFType.java
+++ b/src/main/java/org/orekit/frames/LOFType.java
@@ -160,6 +160,6 @@ public enum LOFType {
      * @param pv position-velocity of the spacecraft in some inertial frame
      * @return rotation from inertial frame to local orbital frame
      */
-    protected abstract Rotation rotationFromInertial(final PVCoordinates pv);
+    protected abstract Rotation rotationFromInertial(PVCoordinates pv);
 
 }

--- a/src/main/java/org/orekit/models/AtmosphericRefractionModel.java
+++ b/src/main/java/org/orekit/models/AtmosphericRefractionModel.java
@@ -30,6 +30,6 @@ public interface AtmosphericRefractionModel extends Serializable {
      * @param trueElevation true elevation (rad)
      * @return refraction angle (rad)
      */
-    double getRefraction(final double trueElevation);
+    double getRefraction(double trueElevation);
 
 }

--- a/src/main/java/org/orekit/models/earth/TroposphericModel.java
+++ b/src/main/java/org/orekit/models/earth/TroposphericModel.java
@@ -32,6 +32,6 @@ public interface TroposphericModel extends Serializable {
      * @param height the height of the station in m above sea level
      * @return the path delay due to the troposphere in m
      */
-    double pathDelay(final double elevation, final double height);
+    double pathDelay(double elevation, double height);
 
 }

--- a/src/main/java/org/orekit/orbits/Orbit.java
+++ b/src/main/java/org/orekit/orbits/Orbit.java
@@ -324,7 +324,7 @@ public abstract class Orbit
      * @param dt time shift in seconds
      * @return a new orbit, shifted with respect to the instance (which is immutable)
      */
-    public abstract Orbit shiftedBy(final double dt);
+    public abstract Orbit shiftedBy(double dt);
 
     /** Compute the Jacobian of the orbital parameters with respect to the Cartesian parameters.
      * <p>
@@ -486,7 +486,7 @@ public abstract class Orbit
      * part must be <em>added</em> to the array components, as the array may already
      * contain some non-zero elements corresponding to non-Keplerian parts)
      */
-    public abstract void addKeplerContribution(final PositionAngle type, final double gm, double[] pDot);
+    public abstract void addKeplerContribution(PositionAngle type, double gm, double[] pDot);
 
         /** Fill a Jacobian half row with a single vector.
      * @param a coefficient of the vector

--- a/src/main/java/org/orekit/orbits/OrbitType.java
+++ b/src/main/java/org/orekit/orbits/OrbitType.java
@@ -324,7 +324,7 @@ public enum OrbitType {
      * @param orbit orbit to convert
      * @return converted orbit with type guaranteed to match (so it can be cast safely)
      */
-    public abstract Orbit convertType(final Orbit orbit);
+    public abstract Orbit convertType(Orbit orbit);
 
     /** Convert orbit to state array.
      * <p>
@@ -365,8 +365,8 @@ public enum OrbitType {
      * @return parameters drivers initialized from reference orbit
      * @exception OrekitException if Jacobian is singular
      */
-    public abstract ParameterDriversList getDrivers(final double dP, final Orbit orbit,
-                                                    final PositionAngle type)
+    public abstract ParameterDriversList getDrivers(double dP, Orbit orbit,
+                                                    PositionAngle type)
         throws OrekitException;
 
     /** Compute scaling factor for parameters drivers.

--- a/src/main/java/org/orekit/propagation/AbstractPropagator.java
+++ b/src/main/java/org/orekit/propagation/AbstractPropagator.java
@@ -248,7 +248,7 @@ public abstract class AbstractPropagator implements Propagator {
     public abstract BoundedPropagator getGeneratedEphemeris();
 
     /** {@inheritDoc} */
-    public abstract <T extends EventDetector> void addEventDetector(final T detector);
+    public abstract <T extends EventDetector> void addEventDetector(T detector);
 
     /** {@inheritDoc} */
     public abstract Collection<EventDetector> getEventsDetectors();

--- a/src/main/java/org/orekit/propagation/Propagator.java
+++ b/src/main/java/org/orekit/propagation/Propagator.java
@@ -171,14 +171,14 @@ public interface Propagator extends PVCoordinatesProvider {
      * @param state new initial state to consider
      * @exception OrekitException if initial state cannot be reset
      */
-    void resetInitialState(final SpacecraftState state)
+    void resetInitialState(SpacecraftState state)
         throws OrekitException;
 
     /** Add a set of user-specified state parameters to be computed along with the orbit propagation.
      * @param additionalStateProvider provider for additional state
      * @exception OrekitException if an additional state with the same name is already present
      */
-    void addAdditionalStateProvider(final AdditionalStateProvider additionalStateProvider)
+    void addAdditionalStateProvider(AdditionalStateProvider additionalStateProvider)
         throws OrekitException;
 
     /** Get an unmodifiable list of providers for additional state.
@@ -210,7 +210,7 @@ public interface Propagator extends PVCoordinatesProvider {
      * @param name name of the additional state
      * @return true if the additional state is managed
      */
-    boolean isAdditionalStateManaged(final String name);
+    boolean isAdditionalStateManaged(String name);
 
     /** Get all the names of all managed states.
      * @return names of all managed states
@@ -223,7 +223,7 @@ public interface Propagator extends PVCoordinatesProvider {
      * @see #getEventsDetectors()
      * @param <T> class type for the generic version
      */
-    <T extends EventDetector> void addEventDetector(final T detector);
+    <T extends EventDetector> void addEventDetector(T detector);
 
     /** Get all the events detectors that have been added.
      * @return an unmodifiable collection of the added detectors
@@ -246,7 +246,7 @@ public interface Propagator extends PVCoordinatesProvider {
     /** Set attitude provider.
      * @param attitudeProvider attitude provider
      */
-    void setAttitudeProvider(final AttitudeProvider attitudeProvider);
+    void setAttitudeProvider(AttitudeProvider attitudeProvider);
 
     /** Get the frame in which the orbit is propagated.
      * <p>

--- a/src/main/java/org/orekit/propagation/analytical/AbstractAnalyticalPropagator.java
+++ b/src/main/java/org/orekit/propagation/analytical/AbstractAnalyticalPropagator.java
@@ -329,7 +329,7 @@ public abstract class AbstractAnalyticalPropagator extends AbstractPropagator {
      * @return mass mass
      * @exception OrekitException if some parameters are out of bounds
      */
-    protected abstract double getMass(final AbsoluteDate date)
+    protected abstract double getMass(AbsoluteDate date)
         throws OrekitException;
 
     /** Get PV coordinates provider.
@@ -345,7 +345,7 @@ public abstract class AbstractAnalyticalPropagator extends AbstractPropagator {
      * propagations after itself
      * @exception OrekitException if initial state cannot be reset
      */
-    protected abstract void resetIntermediateState(final SpacecraftState state, final boolean forward)
+    protected abstract void resetIntermediateState(SpacecraftState state, boolean forward)
         throws OrekitException;
 
     /** Extrapolate an orbit up to a specific target date.
@@ -353,7 +353,7 @@ public abstract class AbstractAnalyticalPropagator extends AbstractPropagator {
      * @return extrapolated parameters
      * @exception OrekitException if some parameters are out of bounds
      */
-    protected abstract Orbit propagateOrbit(final AbsoluteDate date)
+    protected abstract Orbit propagateOrbit(AbsoluteDate date)
         throws OrekitException;
 
     /** Propagate an orbit without any fancy features.

--- a/src/main/java/org/orekit/propagation/conversion/ODEIntegratorBuilder.java
+++ b/src/main/java/org/orekit/propagation/conversion/ODEIntegratorBuilder.java
@@ -33,7 +33,7 @@ public interface ODEIntegratorBuilder {
      * @return a first order integrator ready to use
      * @exception OrekitException if integrator cannot been built
      */
-    AbstractIntegrator buildIntegrator(final Orbit orbit, final OrbitType orbitType)
+    AbstractIntegrator buildIntegrator(Orbit orbit, OrbitType orbitType)
         throws OrekitException;
 
 }

--- a/src/main/java/org/orekit/propagation/conversion/PropagatorBuilder.java
+++ b/src/main/java/org/orekit/propagation/conversion/PropagatorBuilder.java
@@ -35,7 +35,7 @@ public interface PropagatorBuilder {
      * @return an initialized propagator
      * @exception OrekitException if propagator cannot be build
      */
-    Propagator buildPropagator(final double[] normalizedParameters)
+    Propagator buildPropagator(double[] normalizedParameters)
         throws OrekitException;
 
     /** Get the current value of selected normalized parameters.

--- a/src/main/java/org/orekit/propagation/conversion/PropagatorConverter.java
+++ b/src/main/java/org/orekit/propagation/conversion/PropagatorConverter.java
@@ -40,10 +40,10 @@ public interface PropagatorConverter {
      * @return adapted propagator
      * @exception OrekitException if propagator cannot be adapted
      */
-    Propagator convert(final Propagator source,
-                       final double timeSpan,
-                       final int nbPoints,
-                       final List<String> freeParameters) throws OrekitException;
+    Propagator convert(Propagator source,
+                       double timeSpan,
+                       int nbPoints,
+                       List<String> freeParameters) throws OrekitException;
 
     /** Convert a propagator into another one.
      * @param source propagator to convert
@@ -53,10 +53,10 @@ public interface PropagatorConverter {
      * @return adapted propagator
      * @exception OrekitException if propagator cannot be adapted
      */
-    Propagator convert(final Propagator source,
-                       final double timeSpan,
-                       final int nbPoints,
-                       final String ... freeParameters) throws OrekitException;
+    Propagator convert(Propagator source,
+                       double timeSpan,
+                       int nbPoints,
+                       String ... freeParameters) throws OrekitException;
 
     /** Find the propagator that minimize the mean square error for a sample of {@link SpacecraftState states}.
      * @param states spacecraft states sample to fit
@@ -65,9 +65,9 @@ public interface PropagatorConverter {
      * @return adapted propagator
      * @exception OrekitException if propagator cannot be adapted
      */
-    Propagator convert(final List<SpacecraftState> states,
-                       final boolean positionOnly,
-                       final List<String> freeParameters) throws OrekitException;
+    Propagator convert(List<SpacecraftState> states,
+                       boolean positionOnly,
+                       List<String> freeParameters) throws OrekitException;
 
     /** Find the propagator that minimize the mean square error for a sample of {@link SpacecraftState states}.
      * @param states spacecraft states sample to fit
@@ -76,8 +76,8 @@ public interface PropagatorConverter {
      * @return adapted propagator
      * @exception OrekitException if propagator cannot be adapted
      */
-    Propagator convert(final List<SpacecraftState> states,
-                       final boolean positionOnly,
-                       final String ... freeParameters) throws OrekitException;
+    Propagator convert(List<SpacecraftState> states,
+                       boolean positionOnly,
+                       String ... freeParameters) throws OrekitException;
 
 }

--- a/src/main/java/org/orekit/propagation/events/AbstractDetector.java
+++ b/src/main/java/org/orekit/propagation/events/AbstractDetector.java
@@ -173,8 +173,8 @@ public abstract class AbstractDetector<T extends EventDetector> implements Event
      * @param newHandler event handler to call at event occurrences
      * @return a new instance of the appropriate sub-type
      */
-    protected abstract T create(final double newMaxCheck, final double newThreshold,
-                                final int newMaxIter, final EventHandler<? super T> newHandler);
+    protected abstract T create(double newMaxCheck, double newThreshold,
+                                int newMaxIter, EventHandler<? super T> newHandler);
 
     /** Check if the current propagation is forward or backward.
      * @return true if the current propagation is forward

--- a/src/main/java/org/orekit/propagation/integration/AbstractIntegratedPropagator.java
+++ b/src/main/java/org/orekit/propagation/integration/AbstractIntegratedPropagator.java
@@ -356,15 +356,15 @@ public abstract class AbstractIntegratedPropagator extends AbstractPropagator {
      * @param frame inertial frame
      * @return new mapper
      */
-    protected abstract StateMapper createMapper(final AbsoluteDate referenceDate, final double mu,
-                                                final OrbitType orbitType, final PositionAngle positionAngleType,
-                                                final AttitudeProvider attitudeProvider, final Frame frame);
+    protected abstract StateMapper createMapper(AbsoluteDate referenceDate, double mu,
+                                                OrbitType orbitType, PositionAngle positionAngleType,
+                                                AttitudeProvider attitudeProvider, Frame frame);
 
     /** Get the differential equations to integrate (for main state only).
      * @param integ numerical integrator to use for propagation.
      * @return differential equations for main state
      */
-    protected abstract MainStateEquations getMainStateEquations(final ODEIntegrator integ);
+    protected abstract MainStateEquations getMainStateEquations(ODEIntegrator integ);
 
     /** {@inheritDoc} */
     public SpacecraftState propagate(final AbsoluteDate target) throws OrekitException {
@@ -627,7 +627,7 @@ public abstract class AbstractIntegratedPropagator extends AbstractPropagator {
          * @return derivatives of main state
          * @throws OrekitException if differentials cannot be computed
          */
-        double[] computeDerivatives(final SpacecraftState state) throws OrekitException;
+        double[] computeDerivatives(SpacecraftState state) throws OrekitException;
 
     }
 

--- a/src/main/java/org/orekit/propagation/integration/StateMapper.java
+++ b/src/main/java/org/orekit/propagation/integration/StateMapper.java
@@ -173,7 +173,7 @@ public abstract class StateMapper {
      * @return spacecraft state
      * @exception OrekitException if array is inconsistent or cannot be mapped
      */
-    public abstract SpacecraftState mapArrayToState(final AbsoluteDate date, final double[] y, final boolean meanOnly)
+    public abstract SpacecraftState mapArrayToState(AbsoluteDate date, double[] y, boolean meanOnly)
         throws OrekitException;
 
     /** Map a spacecraft state to raw double components.
@@ -181,7 +181,7 @@ public abstract class StateMapper {
      * @param y placeholder where to put the components
      * @exception OrekitException if state is inconsistent or cannot be mapped
      */
-    public abstract void mapStateToArray(final SpacecraftState state, final double[] y)
+    public abstract void mapStateToArray(SpacecraftState state, double[] y)
         throws OrekitException;
 
 }

--- a/src/main/java/org/orekit/propagation/numerical/TimeDerivativesEquations.java
+++ b/src/main/java/org/orekit/propagation/numerical/TimeDerivativesEquations.java
@@ -44,7 +44,7 @@ public interface TimeDerivativesEquations {
      * numerical accuracy.</p>
      * @param mu central body gravitational constant
      */
-    void addKeplerContribution(final double mu);
+    void addKeplerContribution(double mu);
 
     /** Add the contribution of an acceleration expressed in the inertial frame
      *  (it is important to make sure this acceleration is defined in the
@@ -53,20 +53,20 @@ public interface TimeDerivativesEquations {
      * @param y acceleration along the Y axis (m/s²)
      * @param z acceleration along the Z axis (m/s²)
      */
-    void addXYZAcceleration(final double x, final double y, final double z);
+    void addXYZAcceleration(double x, double y, double z);
 
     /** Add the contribution of an acceleration expressed in some inertial frame.
      * @param gamma acceleration vector (m/s²)
      * @param frame frame in which acceleration is defined (must be an inertial frame)
      * @exception OrekitException if frame transforms cannot be computed
      */
-    void addAcceleration(final Vector3D gamma, final Frame frame) throws OrekitException;
+    void addAcceleration(Vector3D gamma, Frame frame) throws OrekitException;
 
     /** Add the contribution of the flow rate (dm/dt).
      * @param q the flow rate, must be negative (dm/dt)
      * @exception IllegalArgumentException if flow-rate is positive
      */
-    void addMassDerivative(final double q);
+    void addMassDerivative(double q);
 
 
 }

--- a/src/main/java/org/orekit/propagation/sampling/OrekitFixedStepHandler.java
+++ b/src/main/java/org/orekit/propagation/sampling/OrekitFixedStepHandler.java
@@ -52,7 +52,7 @@ public interface OrekitFixedStepHandler {
      * @param isLast if true, this is the last integration step
      * @exception OrekitException if step cannot be handled
      */
-    void handleStep(final SpacecraftState currentState, final boolean isLast)
+    void handleStep(SpacecraftState currentState, boolean isLast)
         throws OrekitException;
 
 }

--- a/src/main/java/org/orekit/propagation/sampling/OrekitStepInterpolator.java
+++ b/src/main/java/org/orekit/propagation/sampling/OrekitStepInterpolator.java
@@ -77,7 +77,7 @@ public interface OrekitStepInterpolator {
      * @exception OrekitException if underlying interpolator cannot handle
      * the date
      */
-    SpacecraftState getInterpolatedState(final AbsoluteDate date)
+    SpacecraftState getInterpolatedState(AbsoluteDate date)
         throws OrekitException;
 
     /** Check is integration direction is forward in date.

--- a/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/AbstractGaussianContribution.java
+++ b/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/AbstractGaussianContribution.java
@@ -294,7 +294,7 @@ public abstract class AbstractGaussianContribution implements DSSTForceModel {
      *  @return the integration limits in L
      *  @exception OrekitException if some specific error occurs
      */
-    protected abstract double[] getLLimits(final SpacecraftState state) throws OrekitException;
+    protected abstract double[] getLLimits(SpacecraftState state) throws OrekitException;
 
     /** Computes the mean equinoctial elements rates da<sub>i</sub> / dt.
      *

--- a/src/main/java/org/orekit/utils/IERSConventions.java
+++ b/src/main/java/org/orekit/utils/IERSConventions.java
@@ -1665,7 +1665,7 @@ public enum IERSConventions {
      * @exception OrekitException if fundamental nutation arguments cannot be loaded
      * @since 6.1
      */
-    public abstract FundamentalNutationArguments getNutationArguments(final TimeScale timeScale)
+    public abstract FundamentalNutationArguments getNutationArguments(TimeScale timeScale)
         throws OrekitException;
 
     /** Get the function computing mean obliquity of the ecliptic.


### PR DESCRIPTION
This PR is being created because of violations found in CheckStyle's regression of Orekit during implementation of an improvement.
PR: https://github.com/checkstyle/checkstyle/pull/3388
Issue: https://github.com/checkstyle/checkstyle/issues/3322

We are adding `final` for parameters of methods with no declaration (abstract, native, etc) as a redundant modifier. The change produced new violations in Orekit as seen below:
````
[INFO] There are 94 errors reported by Checkstyle 7.2-SNAPSHOT with /pipeline/source/Orekit/checkstyle.xml ruleset.
[ERROR] src/main/java/org/orekit/orbits/Orbit.java:[327,37] (modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/orekit/orbits/Orbit.java:[489,48] (modifier) RedundantModifier: Redundant 'final' modifier.
[ERROR] src/main/java/org/orekit/orbits/Orbit.java:[489,74] (modifier) RedundantModifier: Redundant 'final' modifier.
....
````

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any questions.
Thanks.