### PR TITLE
Added missing final for variable with anonymous class

### DIFF
--- a/src/main/java/org/orekit/models/earth/EarthITU453AtmosphereRefraction.java
+++ b/src/main/java/org/orekit/models/earth/EarthITU453AtmosphereRefraction.java
@@ -94,7 +94,7 @@ public class EarthITU453AtmosphereRefraction implements AtmosphericRefractionMod
         thetamin = getMinimalElevation(altitude);
         theta0   = thetamin - getTau(thetamin);
 
-        UnivariateFunction refrac = new UnivariateFunction() {
+        final UnivariateFunction refrac = new UnivariateFunction() {
             public double value (final double elev) {
                 return elev + getBaseRefraction(elev);
             }


### PR DESCRIPTION
This PR is being created because of violations found in CheckStyle's regression of Orekit during implementation of a bug fix.
PR: https://github.com/checkstyle/checkstyle/pull/4736
Issue: https://github.com/checkstyle/checkstyle/issues/4727

A bug was found in `FinalLocalVariable` where variables assigned anonymous classes were incorrectly being skipped for detection of this check. The change produced new violations in Orekit as seen below:

````
[INFO] --- maven-checkstyle-plugin:2.17:check (default-cli) @ orekit ---
[INFO] There is 1 error reported by Checkstyle 8.1-SNAPSHOT with /pipeline/source/Orekit/checkstyle.xml ruleset.
[ERROR] src/main/java/org/orekit/models/earth/EarthITU453AtmosphereRefraction.java:[97,28] (coding) FinalLocalVariable: Variable 'refrac' should be declared final.
````
You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any questions.
Thanks.