### PR TITLE
Move extra files into META-INF inside the sources.jar

### DIFF
--- a/src/main/assembly/source-jar-assembly.xml
+++ b/src/main/assembly/source-jar-assembly.xml
@@ -10,6 +10,7 @@
        <include>LICENSE.txt</include>
        <include>NOTICE.txt</include>
       </includes>
+      <outputDirectory>META-INF</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>src/main/java</directory>


### PR DESCRIPTION
The LICENSE.txt and NOTICE.txt files are already stored into the
META-INF of the binary jar file.