### PR TITLE
bump checkstyle version to 8.4

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -71,7 +71,6 @@
                              PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
                              SR_ASSIGN, STAR, STAR_ASSIGN"/>
         </module>
-        <module name="FileContentsHolder"/>
         <module name="SuppressionCommentFilter">
            <property name="offCommentFormat" value="CHECKSTYLE\: stop JavadocVariable check"/>
             <property name="onCommentFormat"  value="CHECKSTYLE\: resume JavadocVariable check"/>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <orekit.maven-bundle-plugin.version>3.3.0</orekit.maven-bundle-plugin.version>
     <orekit.maven-changes-plugin.version>2.12.1</orekit.maven-changes-plugin.version>
     <orekit.maven-checkstyle-plugin.version>2.17</orekit.maven-checkstyle-plugin.version>
-    <orekit.checkstyle.version>8.1</orekit.checkstyle.version>
+    <orekit.checkstyle.version>8.4</orekit.checkstyle.version>
     <orekit.maven-clean-plugin.version>3.0.0</orekit.maven-clean-plugin.version>
     <orekit.maven-compiler-plugin.version>3.6.1</orekit.maven-compiler-plugin.version>
     <orekit.maven-javadoc-plugin.version>2.10.4</orekit.maven-javadoc-plugin.version>


### PR DESCRIPTION
hello from checkstyle project.

WE use your project in regression testing for each commit change, so update for chekstyle is always ok for your project (it even works on 8.5-snapshot).

We need this change to simplify validation on our side, and use your latest code in our testing.