### PR TITLE
Override TLE.equals and TLE.hashCode.

### DIFF
--- a/src/main/java/org/orekit/propagation/analytical/tle/TLE.java
+++ b/src/main/java/org/orekit/propagation/analytical/tle/TLE.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.hipparchus.util.FastMath;
@@ -678,6 +679,64 @@ public class TLE implements TimeStamped, Serializable {
             }
         }
         return sum % 10;
+    }
+
+    /** Check if this tle equals the provided tle.
+     * @param o other tle
+     * @return true if this tle equals the provided tle
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof TLE)) {
+            return false;
+        }
+        TLE tle = (TLE) o;
+        return satelliteNumber == tle.satelliteNumber &&
+                classification == tle.classification &&
+                launchYear == tle.launchYear &&
+                launchNumber == tle.launchNumber &&
+                Objects.equals(launchPiece, tle.launchPiece) &&
+                ephemerisType == tle.ephemerisType &&
+                elementNumber == tle.elementNumber &&
+                Objects.equals(epoch, tle.epoch) &&
+                meanMotion == tle.meanMotion &&
+                meanMotionFirstDerivative == tle.meanMotionFirstDerivative &&
+                meanMotionSecondDerivative == tle.meanMotionSecondDerivative &&
+                eccentricity == tle.eccentricity &&
+                inclination == tle.inclination &&
+                pa == tle.pa &&
+                raan == tle.raan &&
+                meanAnomaly == tle.meanAnomaly &&
+                revolutionNumberAtEpoch == tle.revolutionNumberAtEpoch &&
+                bStar == tle.bStar;
+    }
+
+    /** Get a hashcode for this tle.
+     * @return hashcode
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(satelliteNumber,
+                classification,
+                launchYear,
+                launchNumber,
+                launchPiece,
+                ephemerisType,
+                elementNumber,
+                epoch,
+                meanMotion,
+                meanMotionFirstDerivative,
+                meanMotionSecondDerivative,
+                eccentricity,
+                inclination,
+                pa,
+                raan,
+                meanAnomaly,
+                revolutionNumberAtEpoch,
+                bStar);
     }
 
 }

--- a/src/main/java/org/orekit/propagation/analytical/tle/TLE.java
+++ b/src/main/java/org/orekit/propagation/analytical/tle/TLE.java
@@ -682,6 +682,10 @@ public class TLE implements TimeStamped, Serializable {
     }
 
     /** Check if this tle equals the provided tle.
+     * <p>Due to the difference in precision between object and string
+     * representations of TLE, it is possible for this method to return false
+     * even if string representations returned by {@link #toString()}
+     * are equal.</p>
      * @param o other tle
      * @return true if this tle equals the provided tle
      */

--- a/src/test/java/org/orekit/propagation/analytical/tle/TLETest.java
+++ b/src/test/java/org/orekit/propagation/analytical/tle/TLETest.java
@@ -406,6 +406,24 @@ public class TLETest {
                             1.0e-15);
     }
 
+    @Test
+    public void testEqualTLE() throws OrekitException {
+        TLE tleA = new TLE("1 27421U 02021A   02124.48976499 -.00021470  00000-0 -89879-2 0    20",
+                "2 27421  98.7490 199.5121 0001333 133.9522 226.1918 14.26113993    62");
+        TLE tleB = new TLE("1 27421U 02021A   02124.48976499 -.00021470  00000-0 -89879-2 0    20",
+                "2 27421  98.7490 199.5121 0001333 133.9522 226.1918 14.26113993    62");
+        Assert.assertTrue(tleA.equals(tleB));
+    }
+
+    @Test
+    public void testNonEqualTLE() throws OrekitException {
+        TLE tleA = new TLE("1 27421U 02021A   02124.48976499 -.00021470  00000-0 -89879-2 0    20",
+                "2 27421  98.7490 199.5121 0001333 133.9522 226.1918 14.26113993    62");
+        TLE tleB = new TLE("1 05555U 71086J   12026.96078249 -.00000004  00001-9  01234-9 0  9082",
+                "2 05555  74.0161 228.9750 0075476 328.9888  30.6709 12.26882470804545");
+        Assert.assertFalse(tleA.equals(tleB));
+    }
+
     @Before
     public void setUp() {
         Utils.setDataRoot("regular-data");


### PR DESCRIPTION
When verifying provided function parameters with Mockito, the typical usage pattern of:

```java
TLE OBJECT_TLE = new TLE(...);

Mockito.verify(computer)
    .compute(eq(OBJECT_TLE));
```
cannot be used because `TLE` does not override `Object.equals()`. Instead, we've had to implement equality checking by converting the TLE to a string, and then checking using `argThat`.

```java
TLE OBJECT_TLE = new TLE(...);

Mockito.verify(computer)
    .compute(argThat((tle) -> tle.toString().equals(OBJECT_TLE.toString())));
```