### PR TITLE
Fix endless loop in GPSPropagator.java

### DIFF
--- a/src/main/java/org/orekit/propagation/analytical/gnss/GPSPropagator.java
+++ b/src/main/java/org/orekit/propagation/analytical/gnss/GPSPropagator.java
@@ -356,7 +356,7 @@ public class GPSPropagator extends AbstractAnalyticalPropagator {
         DerivativeStructure term = E;
         DerivativeStructure d    = E.getField().getZero();
         // the inequality test below IS intentional and should NOT be replaced by a check with a small tolerance
-        for (DerivativeStructure x0 = d.add(Double.NaN); x.getValue() != x0.getValue();) {
+        for (DerivativeStructure x0 = d.add(Double.NaN); !x.getValue().equals(x0.getValue());) {
             d = d.add(2);
             term = term.multiply(mE2.divide(d.multiply(d.add(1))));
             x0 = x;


### PR DESCRIPTION
If x.getValue() or/and x0.getValue() is Double.NaN this is a endless loop.