### PR TITLE
remove deprecated allowMissingJavadoc from JavadocMethod

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -35,7 +35,6 @@
         </module>
         <module name="JavadocMethod">
             <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowMissingPropertyJavadoc" value="true"/>
             <property name="validateThrows" value="false"/>
         </module>
         <module name="JavadocStyle"/>


### PR DESCRIPTION
Identified at checkstyle/checkstyle#7088 , `allowMissingJavadoc` is deprecated and doesn't do anything anymore as the check was split into 2 and the functionality of the property was moved to `MissingJavadocMethod`.