### PR TITLE
config: remove allowUndeclaredRTE property from checkstyle JavadocMethod

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,7 +34,6 @@
             <property name="caseIndent"  value="4"/>
         </module>
         <module name="JavadocMethod">
-            <property name="allowUndeclaredRTE" value="true"/>
             <property name="validateThrows" value="false"/>
         </module>
         <module name="JavadocStyle"/>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <orekit.maven-bundle-plugin.version>4.2.0</orekit.maven-bundle-plugin.version>
     <orekit.maven-changes-plugin.version>2.12.1</orekit.maven-changes-plugin.version>
     <orekit.maven-checkstyle-plugin.version>3.1.0</orekit.maven-checkstyle-plugin.version>
-    <orekit.checkstyle.version>8.18</orekit.checkstyle.version>
+    <orekit.checkstyle.version>8.28</orekit.checkstyle.version>
     <orekit.maven-clean-plugin.version>3.1.0</orekit.maven-clean-plugin.version>
     <orekit.maven-compiler-plugin.version>3.8.1</orekit.maven-compiler-plugin.version>
     <orekit.maven-javadoc-plugin.version>3.1.0</orekit.maven-javadoc-plugin.version>


### PR DESCRIPTION
https://checkstyle.org/releasenotes.html#Release_8.28

https://github.com/checkstyle/checkstyle/issues/7329

checkstyle project need this update to continue to keep Orekit in checkstyle's CI verification process.