### PR TITLE
Fix WhitespaceAfterCheck warnings

### DIFF
--- a/src/main/java/org/orekit/bodies/PredefinedIAUPoles.java
+++ b/src/main/java/org/orekit/bodies/PredefinedIAUPoles.java
@@ -1161,7 +1161,7 @@ abstract class PredefinedIAUPoles implements IAUPole {
     public static PredefinedIAUPoles getIAUPole(final EphemerisType body,
                                                 final TimeScales timeScales) {
 
-        switch(body) {
+        switch (body) {
             case SUN :
                 return new Sun(timeScales);
             case MERCURY :

--- a/src/main/java/org/orekit/files/ccsds/ndm/adm/AttitudeType.java
+++ b/src/main/java/org/orekit/files/ccsds/ndm/adm/AttitudeType.java
@@ -80,7 +80,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
 
             Rotation rotation = isFirst ?
                                 new Rotation(components[0], components[1], components[2], components[3], true) :
@@ -142,7 +142,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
             FieldRotation<UnivariateDerivative1> rotation =
                             isFirst ?
                             new FieldRotation<>(new UnivariateDerivative1(components[0], components[4]),
@@ -207,7 +207,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
             // Build the needed objects
             final Rotation rotation = isFirst ?
                                       new Rotation(components[0], components[1], components[2], components[3], true) :
@@ -257,7 +257,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
 
             // Build the needed objects
             Rotation rotation = new Rotation(eulerRotSequence, RotationConvention.FRAME_TRANSFORM,
@@ -311,7 +311,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
 
             // Build the needed objects
             final Rotation rotation = new Rotation(eulerRotSequence,
@@ -374,7 +374,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
 
             // Build the needed objects
             final Rotation rotation = new Rotation(RotationOrder.ZYZ,
@@ -414,7 +414,7 @@ public enum AttitudeType {
                                                    final RotationOrder eulerRotSequence,
                                                    final boolean isSpacecraftBodyRate,
                                                    final AbsoluteDate date,
-                                                   final double...components) {
+                                                   final double... components) {
             // Attitude parameters in the Specified Reference Frame for a Spin Stabilized Satellite
             // are optional in CCSDS AEM format. Support for this attitude type is not implemented
             // yet in Orekit.
@@ -521,7 +521,7 @@ public enum AttitudeType {
      */
     public abstract TimeStampedAngularCoordinates build(boolean isFirst, boolean isExternal2SpacecraftBody,
                                                         RotationOrder eulerRotSequence, boolean isSpacecraftBodyRate,
-                                                        AbsoluteDate date, double...components);
+                                                        AbsoluteDate date, double... components);
 
     /**
      * Get the angular derivative filter corresponding to the attitude data.

--- a/src/main/java/org/orekit/files/sinex/SinexLoader.java
+++ b/src/main/java/org/orekit/files/sinex/SinexLoader.java
@@ -188,7 +188,7 @@ public class SinexLoader {
                     // For now, only few keys are supported
                     // They represent the minimum set of parameters that are interesting to consider in a SINEX file
                     // Other keys can be added depending user needs
-                    switch(line.trim()) {
+                    switch (line.trim()) {
                         case "+SITE/ID" :
                             // Start of site id. data
                             inId = true;
@@ -280,7 +280,7 @@ public class SinexLoader {
                                     // check if this station exists
                                     if (station != null) {
                                         // switch on coordinates data
-                                        switch(parseString(line, 7, 6)) {
+                                        switch (parseString(line, 7, 6)) {
                                             case "STAX":
                                                 // station X coordinate
                                                 final double x = parseDouble(line, 47, 22);

--- a/src/main/java/org/orekit/gnss/RinexObservationLoader.java
+++ b/src/main/java/org/orekit/gnss/RinexObservationLoader.java
@@ -322,7 +322,7 @@ public class RinexObservationLoader {
                         while (readLine(reader, false)) {
 
                             if (rinexHeader == null) {
-                                switch(line.substring(LABEL_START).trim()) {
+                                switch (line.substring(LABEL_START).trim()) {
                                     case COMMENT :
                                         // nothing to do
                                         break;
@@ -673,7 +673,7 @@ public class RinexObservationLoader {
 
                         while (readLine(reader, false)) {
                             if (rinexHeader == null) {
-                                switch(line.substring(LABEL_START).trim()) {
+                                switch (line.substring(LABEL_START).trim()) {
                                     case COMMENT :
                                         // nothing to do
                                         break;
@@ -758,7 +758,7 @@ public class RinexObservationLoader {
                                         interval = parseDouble(0, 10);
                                         break;
                                     case TIME_OF_FIRST_OBS :
-                                        switch(satelliteSystem) {
+                                        switch (satelliteSystem) {
                                             case GPS:
                                                 timeScale = timeScales.getGPS();
                                                 break;

--- a/src/main/java/org/orekit/gnss/antenna/AntexLoader.java
+++ b/src/main/java/org/orekit/gnss/antenna/AntexLoader.java
@@ -214,7 +214,7 @@ public class AntexLoader {
 
                 for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                     ++lineNumber;
-                    switch(line.substring(LABEL_START).trim()) {
+                    switch (line.substring(LABEL_START).trim()) {
                         case "COMMENT" :
                             // nothing to do
                             break;

--- a/src/main/java/org/orekit/gnss/metric/parser/RtcmDataField.java
+++ b/src/main/java/org/orekit/gnss/metric/parser/RtcmDataField.java
@@ -341,7 +341,7 @@ public enum RtcmDataField implements DataField {
         @Override
         public int intValue(final EncodedMessage message) {
             // Word P1 indicates a time interval (in sec) between two adjacent values of tb parameter
-            switch(DataType.BIT_2.decode(message).intValue()) {
+            switch (DataType.BIT_2.decode(message).intValue()) {
                 case 0  : return 0;
                 case 1  : return 1800;
                 case 2  : return 2700;

--- a/src/main/java/org/orekit/models/earth/ionosphere/GlobalIonosphereMapModel.java
+++ b/src/main/java/org/orekit/models/earth/ionosphere/GlobalIonosphereMapModel.java
@@ -548,7 +548,7 @@ public class GlobalIonosphereMapModel extends AbstractSelfFeedingLoader
                 for (line = br.readLine(); line != null; line = br.readLine()) {
                     ++lineNumber;
                     if (line.length() > LABEL_START) {
-                        switch(line.substring(LABEL_START).trim()) {
+                        switch (line.substring(LABEL_START).trim()) {
                             case "EPOCH OF FIRST MAP" :
                                 firstEpoch = parseDate(line);
                                 break;

--- a/src/main/java/org/orekit/utils/AngularCoordinates.java
+++ b/src/main/java/org/orekit/utils/AngularCoordinates.java
@@ -378,7 +378,7 @@ public class AngularCoordinates implements TimeShiftable<AngularCoordinates>, Se
         final DerivativeStructure q1DS;
         final DerivativeStructure q2DS;
         final DerivativeStructure q3DS;
-        switch(order) {
+        switch (order) {
             case 0 :
                 factory = new DSFactory(1, order);
                 q0DS = factory.build(q0);

--- a/src/main/java/org/orekit/utils/FieldAngularCoordinates.java
+++ b/src/main/java/org/orekit/utils/FieldAngularCoordinates.java
@@ -379,7 +379,7 @@ public class FieldAngularCoordinates<T extends CalculusFieldElement<T>> {
         final FieldDerivativeStructure<T> q1DS;
         final FieldDerivativeStructure<T> q2DS;
         final FieldDerivativeStructure<T> q3DS;
-        switch(order) {
+        switch (order) {
             case 0 :
                 factory = new FDSFactory<>(q0.getField(), 1, order);
                 q0DS = factory.build(q0);

--- a/src/main/java/org/orekit/utils/FieldPVCoordinates.java
+++ b/src/main/java/org/orekit/utils/FieldPVCoordinates.java
@@ -356,7 +356,7 @@ public class FieldPVCoordinates<T extends CalculusFieldElement<T>>
         final FieldDerivativeStructure<T> x;
         final FieldDerivativeStructure<T> y;
         final FieldDerivativeStructure<T> z;
-        switch(order) {
+        switch (order) {
             case 0 :
                 factory = new FDSFactory<>(getPosition().getX().getField(), 1, order);
                 x = factory.build(position.getX());
@@ -452,7 +452,7 @@ public class FieldPVCoordinates<T extends CalculusFieldElement<T>>
         final FieldDerivativeStructure<T> x2;
         final FieldDerivativeStructure<T> y2;
         final FieldDerivativeStructure<T> z2;
-        switch(order) {
+        switch (order) {
             case 0 :
                 factory = new FDSFactory<>(getPosition().getX().getField(), 1, order);
                 x0 = factory.build(position.getX());

--- a/src/main/java/org/orekit/utils/PVCoordinates.java
+++ b/src/main/java/org/orekit/utils/PVCoordinates.java
@@ -214,7 +214,7 @@ public class PVCoordinates implements TimeShiftable<PVCoordinates>, Serializable
         final DerivativeStructure x;
         final DerivativeStructure y;
         final DerivativeStructure z;
-        switch(order) {
+        switch (order) {
             case 0 :
                 factory = new DSFactory(1, order);
                 x = factory.build(position.getX());
@@ -310,7 +310,7 @@ public class PVCoordinates implements TimeShiftable<PVCoordinates>, Serializable
         final DerivativeStructure x2;
         final DerivativeStructure y2;
         final DerivativeStructure z2;
-        switch(order) {
+        switch (order) {
             case 0 :
                 factory = new DSFactory(1, order);
                 x0 = factory.build(position.getX());


### PR DESCRIPTION
`WhitespaceAfterCheck` was updated to support `switch`, `varargs` and `lambdas`, CI was failing on Orekit project.
Related checkstyle PR - 
https://github.com/checkstyle/checkstyle/pull/11299
https://github.com/checkstyle/checkstyle/pull/11198

CI failure - https://app.travis-ci.com/github/checkstyle/checkstyle/jobs/559090017