### PR TITLE
Fix code style problem

### DIFF
--- a/src/main/java/org/orekit/forces/maneuvers/ConfigurableLowThrustManeuver.java
+++ b/src/main/java/org/orekit/forces/maneuvers/ConfigurableLowThrustManeuver.java
@@ -126,7 +126,7 @@ public class ConfigurableLowThrustManeuver extends Maneuver {
      * @return thrust force (N).
      */
     public double getThrust() {
-        return ((AbstractConstantThrustPropulsionModel) (getPropulsionModel())).getThrustVector().getNorm();
+        return ((AbstractConstantThrustPropulsionModel) getPropulsionModel()).getThrustVector().getNorm();
     }
 
     /**
@@ -135,7 +135,7 @@ public class ConfigurableLowThrustManeuver extends Maneuver {
      * @return specific impulse (s).
      */
     public double getISP() {
-        return ((AbstractConstantThrustPropulsionModel) (getPropulsionModel())).getIsp();
+        return ((AbstractConstantThrustPropulsionModel) getPropulsionModel()).getIsp();
     }
 
 }

--- a/src/main/java/org/orekit/forces/maneuvers/ConstantThrustManeuver.java
+++ b/src/main/java/org/orekit/forces/maneuvers/ConstantThrustManeuver.java
@@ -194,7 +194,7 @@ public class ConstantThrustManeuver extends Maneuver {
      * @return thrust vector (N) in S/C frame.
      */
     public Vector3D getThrustVector() {
-        return ((AbstractConstantThrustPropulsionModel) (getPropulsionModel())).getThrustVector();
+        return ((AbstractConstantThrustPropulsionModel) getPropulsionModel()).getThrustVector();
     }
 
     /** Get the thrust.
@@ -208,14 +208,14 @@ public class ConstantThrustManeuver extends Maneuver {
      * @return specific impulse (s).
      */
     public double getISP() {
-        return ((AbstractConstantThrustPropulsionModel) (getPropulsionModel())).getIsp();
+        return ((AbstractConstantThrustPropulsionModel) getPropulsionModel()).getIsp();
     }
 
     /** Get the flow rate.
      * @return flow rate (negative, kg/s).
      */
     public double getFlowRate() {
-        return ((AbstractConstantThrustPropulsionModel) (getPropulsionModel())).getFlowRate();
+        return ((AbstractConstantThrustPropulsionModel) getPropulsionModel()).getFlowRate();
     }
 
     /** Get the direction.
@@ -231,7 +231,7 @@ public class ConstantThrustManeuver extends Maneuver {
      * @since 9.2
      */
     public AbsoluteDate getStartDate() {
-        return ((DateBasedManeuverTriggers) (getManeuverTriggers())).getStartDate();
+        return ((DateBasedManeuverTriggers) getManeuverTriggers()).getStartDate();
     }
 
     /** Get the end date.
@@ -239,7 +239,7 @@ public class ConstantThrustManeuver extends Maneuver {
      * @since 9.2
      */
     public AbsoluteDate getEndDate() {
-        return ((DateBasedManeuverTriggers) (getManeuverTriggers())).getEndDate();
+        return ((DateBasedManeuverTriggers) getManeuverTriggers()).getEndDate();
     }
 
     /** Get the duration of the maneuver (s).
@@ -248,7 +248,7 @@ public class ConstantThrustManeuver extends Maneuver {
      * @since 9.2
      */
     public double getDuration() {
-        return ((DateBasedManeuverTriggers) (getManeuverTriggers())).getDuration();
+        return ((DateBasedManeuverTriggers) getManeuverTriggers()).getDuration();
     }
 
     /** Check if maneuvering is on.


### PR DESCRIPTION
It seems that the parentheses of getter methods below are unnecessary, can I remove them?  
The pull request of [Issue #11643](https://github.com/checkstyle/checkstyle/pull/11673) of [checkstyle](https://github.com/checkstyle/checkstyle) has metioned this problem. The unnecessary parentheses is a violation in checkstyle.

Thank you.