### PR TITLE
Fix invalid Javadoc syntax and missing final modifiers

### DIFF
--- a/src/main/java/org/orekit/forces/ForceModel.java
+++ b/src/main/java/org/orekit/forces/ForceModel.java
@@ -153,7 +153,7 @@ public interface ForceModel extends ParameterDriversProvider, EventDetectorsProv
      * @return mass rate (kg/s)
      * @since 13.1
      */
-    default <T extends CalculusFieldElement<T>> T getMassDerivative(FieldSpacecraftState<T> state, T[] parameters) {
+    default <T extends CalculusFieldElement<T>> T getMassDerivative(final FieldSpacecraftState<T> state, final T[] parameters) {
         return state.getMass().getField().getZero();
     }
 

--- a/src/main/java/org/orekit/propagation/events/EnablingPredicate.java
+++ b/src/main/java/org/orekit/propagation/events/EnablingPredicate.java
@@ -41,7 +41,7 @@ public interface EnablingPredicate {
      * @return combined predicate
      * @since 13.1
      */
-    static EnablingPredicate orCombine(EnablingPredicate... enablingPredicates) {
+    static EnablingPredicate orCombine(final EnablingPredicate... enablingPredicates) {
         return (state, detector, g) -> Arrays.stream(enablingPredicates).anyMatch(p -> p.eventIsEnabled(state, detector, g));
     }
 
@@ -51,7 +51,7 @@ public interface EnablingPredicate {
      * @return combined predicate
      * @since 13.1
      */
-    static EnablingPredicate andCombine(EnablingPredicate... enablingPredicates) {
+    static EnablingPredicate andCombine(final EnablingPredicate... enablingPredicates) {
         return (state, detector, g) -> Arrays.stream(enablingPredicates).allMatch(p -> p.eventIsEnabled(state, detector, g));
     }
 }

--- a/src/main/java/org/orekit/propagation/events/FieldEnablingPredicate.java
+++ b/src/main/java/org/orekit/propagation/events/FieldEnablingPredicate.java
@@ -45,7 +45,7 @@ public interface FieldEnablingPredicate<T extends CalculusFieldElement<T>> {
      * @since 13.1
      */
     @SafeVarargs
-    static <T extends CalculusFieldElement<T>> FieldEnablingPredicate<T> orCombine(FieldEnablingPredicate<T>... enablingPredicates) {
+    static <T extends CalculusFieldElement<T>> FieldEnablingPredicate<T> orCombine(final FieldEnablingPredicate<T>... enablingPredicates) {
         return (state, detector, g) -> Arrays.stream(enablingPredicates).anyMatch(p -> p.eventIsEnabled(state, detector, g));
     }
 
@@ -57,7 +57,7 @@ public interface FieldEnablingPredicate<T extends CalculusFieldElement<T>> {
      * @since 13.1
      */
     @SafeVarargs
-    static <T extends CalculusFieldElement<T>> FieldEnablingPredicate<T> andCombine(FieldEnablingPredicate<T>... enablingPredicates) {
+    static <T extends CalculusFieldElement<T>> FieldEnablingPredicate<T> andCombine(final FieldEnablingPredicate<T>... enablingPredicates) {
         return (state, detector, g) -> Arrays.stream(enablingPredicates).allMatch(p -> p.eventIsEnabled(state, detector, g));
     }
 }

--- a/src/main/java/org/orekit/propagation/integration/AbstractIntegratedPropagator.java
+++ b/src/main/java/org/orekit/propagation/integration/AbstractIntegratedPropagator.java
@@ -1332,7 +1332,7 @@ public abstract class AbstractIntegratedPropagator extends AbstractPropagator {
      * If propagator-specific event handlers and step handlers are added to
      * the integrator in the try block, they will be removed automatically
      * when leaving the block, so the integrator only keeps its own handlers
-     * between calls to {@link AbstractIntegratedPropagator#propagate(AbsoluteDate, AbsoluteDate).
+     * between calls to {@link AbstractIntegratedPropagator#propagate(AbsoluteDate, AbsoluteDate)}.
      * </p>
      * @since 11.0
      */

--- a/src/main/java/org/orekit/propagation/integration/FieldAbstractIntegratedPropagator.java
+++ b/src/main/java/org/orekit/propagation/integration/FieldAbstractIntegratedPropagator.java
@@ -1321,7 +1321,7 @@ public abstract class FieldAbstractIntegratedPropagator<T extends CalculusFieldE
      * If propagator-specific event handlers and step handlers are added to
      * the integrator in the try block, they will be removed automatically
      * when leaving the block, so the integrator only keep its own handlers
-     * between calls to {@link FieldAbstractIntegratedPropagator#propagate(FieldAbsoluteDate, FieldAbsoluteDate).
+     * between calls to {@link FieldAbstractIntegratedPropagator#propagate(FieldAbsoluteDate, FieldAbsoluteDate)}.
      * </p>
      * @param <T> the type of the field elements
      * @since 11.0

--- a/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTThirdBody.java
+++ b/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTThirdBody.java
@@ -1393,7 +1393,7 @@ public class DSSTThirdBody implements DSSTForceModel {
      * Starting from Danielson 4.2-9,10,11 and taking into account that fact that: <br />
      * c = e / (1 + (1 - e²)<sup>1/2</sup>) = e / (1 + B) = e * b <br/>
      * the expression e<sup>-|j-s|</sup>*w<sub>j</sub><sup>n, s</sup>
-     * can be written as: <br/ >
+     * can be written as: <br />
      * - for |s| > |j| <br />
      * e<sup>-|j-s|</sup>*w<sub>j</sub><sup>n, s</sup> =
      *          (((n + s)!(n - s)!)/((n + j)!(n - j)!)) *
@@ -1579,7 +1579,7 @@ public class DSSTThirdBody implements DSSTForceModel {
     * Starting from Danielson 4.2-9,10,11 and taking into account that fact that: <br />
     * c = e / (1 + (1 - e²)<sup>1/2</sup>) = e / (1 + B) = e * b <br/>
     * the expression e<sup>-|j-s|</sup>*w<sub>j</sub><sup>n, s</sup>
-    * can be written as: <br/ >
+    * can be written as: <br />
     * - for |s| > |j| <br />
     * e<sup>-|j-s|</sup>*w<sub>j</sub><sup>n, s</sup> =
     *          (((n + s)!(n - s)!)/((n + j)!(n - j)!)) *
@@ -2016,7 +2016,7 @@ public class DSSTThirdBody implements DSSTForceModel {
     /** This class computes the terms containing the coefficients C<sub>j</sub> and S<sub>j</sub> of (α, β) or (k, h).
      *
      * <p>
-     * The following terms and their derivatives by k, h, alpha and beta are considered: <br/ >
+     * The following terms and their derivatives by k, h, alpha and beta are considered: <br />
      * - sign(j-s) * C<sub>s</sub>(α, β) * S<sub>|j-s|</sub>(k, h) + S<sub>s</sub>(α, β) * C<sub>|j-s|</sub>(k, h) <br />
      * - C<sub>s</sub>(α, β) * S<sub>j+s</sub>(k, h) - S<sub>s</sub>(α, β) * C<sub>j+s</sub>(k, h) <br />
      * - C<sub>s</sub>(α, β) * C<sub>|j-s|</sub>(k, h) - sign(j-s) * S<sub>s</sub>(α, β) * S<sub>|j-s|</sub>(k, h) <br />
@@ -2274,7 +2274,7 @@ public class DSSTThirdBody implements DSSTForceModel {
      /** This class computes the terms containing the coefficients C<sub>j</sub> and S<sub>j</sub> of (α, β) or (k, h).
      *
      * <p>
-     * The following terms and their derivatives by k, h, alpha and beta are considered: <br/ >
+     * The following terms and their derivatives by k, h, alpha and beta are considered: <br />
      * - sign(j-s) * C<sub>s</sub>(α, β) * S<sub>|j-s|</sub>(k, h) + S<sub>s</sub>(α, β) * C<sub>|j-s|</sub>(k, h) <br />
      * - C<sub>s</sub>(α, β) * S<sub>j+s</sub>(k, h) - S<sub>s</sub>(α, β) * C<sub>j+s</sub>(k, h) <br />
      * - C<sub>s</sub>(α, β) * C<sub>|j-s|</sub>(k, h) - sign(j-s) * S<sub>s</sub>(α, β) * S<sub>|j-s|</sub>(k, h) <br />

--- a/src/main/java/org/orekit/time/FieldTimeStamped.java
+++ b/src/main/java/org/orekit/time/FieldTimeStamped.java
@@ -71,7 +71,7 @@ public interface FieldTimeStamped<T extends CalculusFieldElement<T>> {
      * @see FieldAbsoluteDate#durationFrom(AbsoluteDate)
      * @since 131
      */
-    default T durationFrom(TimeStamped timeStamped) {
+    default T durationFrom(final TimeStamped timeStamped) {
         return getDate().durationFrom(timeStamped.getDate());
     }
 


### PR DESCRIPTION
This PR fixes invalid HTML syntax found in Javadoc comments, specifically:
- Malformed `<br/>` tags (changed to standard `<br />`).
- Unclosed `{@link}` tags (added missing closing braces).

It also adds missing `final` modifiers to method parameters.

These syntax errors cause parsing failures in newer versions of Checkstyle and stricter Javadoc tools. Fixing them allows the codebase to be validated against modern tools while maintaining full compatibility with the current setup.

> I did **not** upgrade the Checkstyle version in `pom.xml` to preserve JDK 8 compatibility as noted in the project configuration.