### PR TITLE
Remove obsolete JavadocStyle check and fix FinalParameters violations

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -37,7 +37,6 @@
         <module name="JavadocMethod">
             <property name="validateThrows" value="false"/>
         </module>
-        <module name="JavadocStyle"/>
         <module name="JavadocVariable"/>
         <module name="MissingSwitchDefault"/>
         <module name="ModifierOrder"/>

--- a/src/main/java/org/orekit/files/ccsds/utils/generation/Generator.java
+++ b/src/main/java/org/orekit/files/ccsds/utils/generation/Generator.java
@@ -92,7 +92,8 @@ public interface Generator extends AutoCloseable {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // we want to use Optional here to avoid having to call orElse(null) everywhere
-    default void writeOptionalStringEntry(String key, Optional<String> value, Unit unit, boolean mandatory) throws IOException {
+    default void writeOptionalStringEntry(final String key, final Optional<String> value,
+                                          final Unit unit, final boolean mandatory) throws IOException {
         writeEntry(key, value.orElse(null), unit, mandatory);
     }
 
@@ -123,7 +124,8 @@ public interface Generator extends AutoCloseable {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // we want to use Optional here to avoid having to call value.map(Enum::name) everywhere
-    default void writeOptionalEnumEntry(String key, Optional<? extends Enum<?>> value, boolean mandatory) throws IOException {
+    default void writeOptionalEnumEntry(final String key, final Optional<? extends Enum<?>> value,
+                                        final boolean mandatory) throws IOException {
         writeEntry(key, value.map(Enum::name).orElse(null), null, mandatory);
     }
 
@@ -150,7 +152,9 @@ public interface Generator extends AutoCloseable {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // we want to use Optional here to avoid having to call orElse(null) everywhere
-    default void writeOptionalDateEntry(String key, TimeConverter converter, Optional<AbsoluteDate> date, boolean forceCalendar, boolean mandatory) throws IOException {
+    default void writeOptionalDateEntry(final String key, final TimeConverter converter,
+                                        final Optional<AbsoluteDate> date, final boolean forceCalendar,
+                                        final boolean mandatory) throws IOException {
         writeEntry(key, converter, date.orElse(null), forceCalendar, mandatory);
     }
 
@@ -198,7 +202,8 @@ public interface Generator extends AutoCloseable {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // we want to use Optional here to avoid having to call value.isPresent() everywhere
-    default void writeOptionalIntEntry(String key, Optional<Integer> value, boolean mandatory) throws IOException {
+    default void writeOptionalIntEntry(final String key, final Optional<Integer> value,
+                                       final boolean mandatory) throws IOException {
         writeEntry(key, value.map(integer -> Integer.toString(integer)).orElse(null), null, mandatory);
     }
 
@@ -232,7 +237,8 @@ public interface Generator extends AutoCloseable {
      * @throws IOException if an I/O error occurs.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // we want to use Optional here to avoid having to call orElse(Double.NaN) everywhere
-    default void writeOptionalDoubleEntry(String key, Optional<Double> value, Unit unit, boolean mandatory) throws IOException {
+    default void writeOptionalDoubleEntry(final String key, final Optional<Double> value,
+                                          final Unit unit, final boolean mandatory) throws IOException {
         writeEntry(key, value.orElse(Double.NaN), unit, mandatory);
     }
 
@@ -291,7 +297,7 @@ public interface Generator extends AutoCloseable {
      * @return date as a string
      * @since 13.1.6
      */
-    default String dateToString(DateTimeComponents dt) {
+    default String dateToString(final DateTimeComponents dt) {
         final DateComponents date = dt.getDate();
         final TimeComponents time = dt.getTime();
         return dateToString(date.getYear(), date.getMonth(), date.getDay(),

--- a/src/main/java/org/orekit/gnss/metric/parser/DataField.java
+++ b/src/main/java/org/orekit/gnss/metric/parser/DataField.java
@@ -59,7 +59,7 @@ public interface DataField {
      * @param n number of bits to decode
      * @return long value of the field
      */
-    default long longValue(final EncodedMessage message, int n) {
+    default long longValue(final EncodedMessage message, final int n) {
         // this method should be overwritten
         throw new OrekitInternalError(null);
     }

--- a/src/main/java/org/orekit/utils/Formatter.java
+++ b/src/main/java/org/orekit/utils/Formatter.java
@@ -67,7 +67,7 @@ public interface Formatter {
      * @return date formatted to match the following format [yyyy-MM-ddTHH:mm:ss.S#]
      * @since 13.1.6
      */
-    default String toString(DateTimeComponents dt) {
+    default String toString(final DateTimeComponents dt) {
         final DateComponents date = dt.getDate();
         final TimeComponents time = dt.getTime();
         return toString(date.getYear(), date.getMonth(), date.getDay(),


### PR DESCRIPTION
Removes the obsolete `JavadocStyle` check because it is being removed from Checkstyle in [checkstyle/checkstyle#20582](https://github.com/checkstyle/checkstyle/pull/20582).

If this project wants to keep validating Javadoc summaries, `SummaryJavadoc` is the more reliable replacement because it specifically validates summary text. I did not add it here because it currently introduces 77 violations, so that migration should be handled separately.

While validating the updated configuration with a current Checkstyle snapshot, `FinalParameters` reported missing `final` modifiers in a few default methods. This PR adds those modifiers so the project remains clean.